### PR TITLE
crash when used in multiple apps

### DIFF
--- a/src/android/PanasonicScanner.java
+++ b/src/android/PanasonicScanner.java
@@ -45,13 +45,9 @@ public class PanasonicScanner extends CordovaPlugin  implements BarcodeListener,
         @Override
         protected Boolean doInBackground(BarcodeReader... params) {
             try {
-                params[0].enable(10000);
                 params[0].addBarcodeListener(PanasonicScanner.this);
                 return true;
-            } catch (BarcodeException ex) {
-                Log.e(TAG, ex.toString());
-                return false;
-            } catch (TimeoutException ex) {
+            } catch (Exception ex) {
                 Log.e(TAG, ex.toString());
                 return false;
             }


### PR DESCRIPTION
the params[0].enable(10000) causes a crash when this plugin in used in multiple apps on a single device and are to be run at the same time(without closing the apps). Works for android 6.0.1 on a panasonic FZ-N1 device.